### PR TITLE
keep proportions

### DIFF
--- a/src/ofxBlurUtils.cpp
+++ b/src/ofxBlurUtils.cpp
@@ -275,7 +275,7 @@ void ofxBlurUtils::endRGB(){
             
         }
         else{
-            pong.draw(0, 0, ofGetWindowWidth(), ofGetWindowHeight());
+            pong.draw(0, 0, ww, hh);
         }
         
     }


### PR DESCRIPTION
When the blur effect is applied to a an image, the dimension get automatically scaled to cover the whole window. This is not the expected behaviour considered that in the setup the width and the height are explicitly set.